### PR TITLE
Merge MapRenderer refactor into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+docs/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="JavadocGenerationManager">
+    <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/docs" />
+    <option name="OPTION_SCOPE" value="private" />
+  </component>
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/RenderingSystem.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/RenderingSystem.java
@@ -13,6 +13,7 @@ public class RenderingSystem extends EntitySystem
 
   public RenderingSystem(SpriteBatch spriteBatch) {
     this.spriteBatch = spriteBatch;
+
     renderableMapper = ComponentMapper.getFor(RenderableComponent.class);
   }
 
@@ -31,6 +32,7 @@ public class RenderingSystem extends EntitySystem
         renderable.renderer.render(entity, spriteBatch);
       }
     }
+
     spriteBatch.end();
   }
 }

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/RenderingSystem.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/RenderingSystem.java
@@ -5,23 +5,42 @@ import com.badlogic.ashley.core.*;
 import com.badlogic.ashley.utils.ImmutableArray;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
+/**
+ * The RenderingSystem class is responsible for rendering entities with RenderableComponents.
+ */
 public class RenderingSystem extends EntitySystem
 {
   private final SpriteBatch spriteBatch;
   private final ComponentMapper<RenderableComponent> renderableMapper;
   private ImmutableArray<Entity> entities;
 
+  /**
+   * Constructs a RenderingSystem instance with a SpriteBatch for rendering.
+   *
+   * @param spriteBatch The SpriteBatch used for rendering.
+   */
   public RenderingSystem(SpriteBatch spriteBatch) {
     this.spriteBatch = spriteBatch;
 
     renderableMapper = ComponentMapper.getFor(RenderableComponent.class);
   }
 
+  /**
+   * Called when the RenderingSystem is added to the engine. Initializes the list of entities to render.
+   *
+   * @param engine The Ashley engine to which this system is added.
+   */
   @Override
   public void addedToEngine(Engine engine) {
+    // Get all entities with RenderableComponent
     entities = getEngine().getEntitiesFor(Family.all(RenderableComponent.class).get());
   }
 
+  /**
+   * Update method for rendering entities with RenderableComponents.
+   *
+   * @param deltaTime The time elapsed since the last frame.
+   */
   @Override
   public void update(float deltaTime) {
     spriteBatch.begin();
@@ -29,6 +48,7 @@ public class RenderingSystem extends EntitySystem
       RenderableComponent renderable = renderableMapper.get(entity);
 
       if (renderable.renderer != null) {
+        // Call the renderer's render method to render the entity
         renderable.renderer.render(entity, spriteBatch);
       }
     }

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/StaticTileMapRenderer.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/StaticTileMapRenderer.java
@@ -1,12 +1,16 @@
-package ca.cgutwin.deckedout2.world;
+package ca.cgutwin.deckedout2.rendering;
 
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
 
-public class MapRenderer extends OrthogonalTiledMapRenderer
+public class StaticTileMapRenderer extends OrthogonalTiledMapRenderer
 {
-  public MapRenderer(TiledMap map) {
+  public StaticTileMapRenderer() {
+    this(null);
+  }
+
+  public StaticTileMapRenderer(TiledMap map) {
     super(map, 32);
   }
 

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/StaticTileMapRenderer.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/StaticTileMapRenderer.java
@@ -4,16 +4,34 @@ import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
 
+/**
+ * The StaticTileMapRenderer class extends OrthogonalTiledMapRenderer and is used to render a TiledMap with static
+ * tiles.
+ * It filters out and does not render tiles with the "entity" property set to true.
+ */
 public class StaticTileMapRenderer extends OrthogonalTiledMapRenderer
 {
+  /**
+   * Constructs a StaticTileMapRenderer with no initial map.
+   */
   public StaticTileMapRenderer() {
     this(null);
   }
 
+  /**
+   * Constructs a StaticTileMapRenderer with the specified TiledMap and unit scale.
+   *
+   * @param map The TiledMap to render.
+   */
   public StaticTileMapRenderer(TiledMap map) {
-    super(map, 32);
+    super(map, 32); // Use a unit scale of 32
   }
 
+  /**
+   * Renders a specific tile layer, excluding tiles with the "entity" property set to true.
+   *
+   * @param layer The TiledMapTileLayer to render.
+   */
   @Override
   public void renderTileLayer(TiledMapTileLayer layer) {
     for (int x = 0; x < layer.getWidth(); x++) {
@@ -23,8 +41,10 @@ public class StaticTileMapRenderer extends OrthogonalTiledMapRenderer
 
         if (cell != null && cell.getTile() != null) {
 
+          // Check if the tile has the "entity" property set to true
           Boolean isEntity = cell.getTile().getProperties().get("entity", Boolean.class);
 
+          // If it's not an entity (or is null), render the tile
           if (isEntity == null || !isEntity) {
             batch.draw(cell.getTile().getTextureRegion(), x*getUnitScale(), y*getUnitScale());
           }

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/components/RenderableComponent.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/components/RenderableComponent.java
@@ -4,11 +4,27 @@ import ca.cgutwin.deckedout2.rendering.Renderer;
 import com.badlogic.ashley.core.Component;
 import com.badlogic.gdx.graphics.Camera;
 
+/**
+ * The RenderableComponent class represents a component that associates an entity with a renderer and a camera.
+ * It is used to specify how an entity should be rendered and which camera to use for rendering.
+ */
 public class RenderableComponent implements Component
 {
+  /**
+   * The renderer responsible for rendering the entity.
+   */
   public Renderer renderer;
+
+  /**
+   * The camera used for rendering the entity.
+   */
   public Camera camera;
 
+  /**
+   * Constructs a RenderableComponent with the specified renderer.
+   *
+   * @param renderer The renderer responsible for rendering the entity.
+   */
   public RenderableComponent(Renderer renderer) {
     this.renderer = renderer;
   }

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/components/RenderableComponent.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/components/RenderableComponent.java
@@ -2,10 +2,12 @@ package ca.cgutwin.deckedout2.rendering.components;
 
 import ca.cgutwin.deckedout2.rendering.Renderer;
 import com.badlogic.ashley.core.Component;
+import com.badlogic.gdx.graphics.Camera;
 
 public class RenderableComponent implements Component
 {
   public Renderer renderer;
+  public Camera camera;
 
   public RenderableComponent(Renderer renderer) {
     this.renderer = renderer;

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/renderers/MapRenderer.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/renderers/MapRenderer.java
@@ -1,0 +1,28 @@
+package ca.cgutwin.deckedout2.rendering.renderers;
+
+import ca.cgutwin.deckedout2.rendering.Renderer;
+import ca.cgutwin.deckedout2.rendering.StaticTileMapRenderer;
+import ca.cgutwin.deckedout2.rendering.components.RenderableComponent;
+import ca.cgutwin.deckedout2.world.components.MapComponent;
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+
+public class MapRenderer implements Renderer
+{
+  StaticTileMapRenderer staticTileMapRenderer;
+
+  public MapRenderer() {
+    staticTileMapRenderer = new StaticTileMapRenderer();
+  }
+
+  @Override
+  public void render(Entity entity, SpriteBatch spriteBatch) {
+    MapComponent mapComponent = entity.getComponent(MapComponent.class);
+    RenderableComponent renderableComponent = entity.getComponent(RenderableComponent.class);
+    if (staticTileMapRenderer.getMap() == null) { staticTileMapRenderer.setMap(mapComponent.map); }
+
+    staticTileMapRenderer.setView((OrthographicCamera) renderableComponent.camera);
+    staticTileMapRenderer.render();
+  }
+}

--- a/src/main/java/ca/cgutwin/deckedout2/rendering/renderers/MapRenderer.java
+++ b/src/main/java/ca/cgutwin/deckedout2/rendering/renderers/MapRenderer.java
@@ -8,21 +8,41 @@ import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
+/**
+ * The MapRenderer class implements the Renderer interface and is responsible for rendering the game map.
+ * It uses a StaticTileMapRenderer to render the map as static tiles.
+ */
 public class MapRenderer implements Renderer
 {
-  StaticTileMapRenderer staticTileMapRenderer;
+  private final StaticTileMapRenderer staticTileMapRenderer;
 
+  /**
+   * Constructs a MapRenderer instance and initializes the StaticTileMapRenderer.
+   */
   public MapRenderer() {
     staticTileMapRenderer = new StaticTileMapRenderer();
   }
 
+  /**
+   * Renders the map associated with the given entity using the provided SpriteBatch.
+   *
+   * @param entity      The entity containing the MapComponent and RenderableComponent.
+   * @param spriteBatch The SpriteBatch used for rendering.
+   */
   @Override
   public void render(Entity entity, SpriteBatch spriteBatch) {
     MapComponent mapComponent = entity.getComponent(MapComponent.class);
     RenderableComponent renderableComponent = entity.getComponent(RenderableComponent.class);
-    if (staticTileMapRenderer.getMap() == null) { staticTileMapRenderer.setMap(mapComponent.map); }
 
+    // Set the map for the StaticTileMapRenderer if not already set
+    if (staticTileMapRenderer.getMap() == null) {
+      staticTileMapRenderer.setMap(mapComponent.map);
+    }
+
+    // Set the view of the StaticTileMapRenderer to match the camera
     staticTileMapRenderer.setView((OrthographicCamera) renderableComponent.camera);
+
+    // Render the map using the StaticTileMapRenderer
     staticTileMapRenderer.render();
   }
 }

--- a/src/main/java/ca/cgutwin/deckedout2/screens/DungeonScreen.java
+++ b/src/main/java/ca/cgutwin/deckedout2/screens/DungeonScreen.java
@@ -16,6 +16,9 @@ import com.badlogic.gdx.physics.box2d.Box2DDebugRenderer;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 
+/**
+ * The DungeonScreen class represents the screen for the dungeon gameplay.
+ */
 public class DungeonScreen implements Screen
 {
   private final Box2DDebugRenderer worldRenderer;
@@ -24,7 +27,11 @@ public class DungeonScreen implements Screen
   OrthographicCamera camera;
   Viewport viewport;
 
-
+  /**
+   * Constructs a DungeonScreen instance.
+   *
+   * @param parent The GameRunner instance that manages the game.
+   */
   public DungeonScreen(GameRunner parent) {
     this.parent    = parent;
     this.camera    = new OrthographicCamera();
@@ -35,6 +42,7 @@ public class DungeonScreen implements Screen
     viewport = new ExtendViewport(10*32, 10*32, camera);
     camera.update();
 
+    // Add various systems to the Ashley engine
     parent.engine().addSystem(new PhysicsSystem(parent.world()));
     parent.engine().addSystem(new RenderingSystem(parent.sb()));
     parent.engine().addSystem(new CollisionSystem(parent.world()));
@@ -83,5 +91,6 @@ public class DungeonScreen implements Screen
 
   @Override
   public void dispose() {
+    // Dispose of any resources here if needed.
   }
 }

--- a/src/main/java/ca/cgutwin/deckedout2/screens/DungeonScreen.java
+++ b/src/main/java/ca/cgutwin/deckedout2/screens/DungeonScreen.java
@@ -8,7 +8,6 @@ import ca.cgutwin.deckedout2.player.PlayerMovementSystem;
 import ca.cgutwin.deckedout2.rendering.RenderingSystem;
 import ca.cgutwin.deckedout2.util.DebugSystem;
 import ca.cgutwin.deckedout2.world.MapLoader;
-import ca.cgutwin.deckedout2.world.MapRenderer;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.GL20;
@@ -19,7 +18,6 @@ import com.badlogic.gdx.utils.viewport.Viewport;
 
 public class DungeonScreen implements Screen
 {
-  private final MapRenderer mapRenderer;
   private final Box2DDebugRenderer worldRenderer;
   GameRunner parent;
   MapLoader mapLoader;
@@ -28,14 +26,12 @@ public class DungeonScreen implements Screen
 
 
   public DungeonScreen(GameRunner parent) {
-    this.parent      = parent;
-    this.mapLoader   = new MapLoader(parent.engine(), "tiledmap/untitled.tmx");
-    this.mapRenderer = new MapRenderer(mapLoader.map());
+    this.parent    = parent;
+    this.camera    = new OrthographicCamera();
+    this.mapLoader = new MapLoader(parent.engine(), camera, "tiledmap/untitled.tmx");
 
     worldRenderer = new Box2DDebugRenderer();
 
-
-    camera   = new OrthographicCamera();
     viewport = new ExtendViewport(10*32, 10*32, camera);
     camera.update();
 
@@ -58,12 +54,11 @@ public class DungeonScreen implements Screen
     Gdx.gl.glClearColor(0, 0, 0, 1);
     Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
     Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
     viewport.apply(true);
     parent.sb().setProjectionMatrix(camera.combined);
 
     worldRenderer.render(parent.world(), camera.combined);
-    mapRenderer.render();
-    mapRenderer.setView(camera);
   }
 
   @Override

--- a/src/main/java/ca/cgutwin/deckedout2/world/MapLoader.java
+++ b/src/main/java/ca/cgutwin/deckedout2/world/MapLoader.java
@@ -2,11 +2,14 @@ package ca.cgutwin.deckedout2.world;
 
 import ca.cgutwin.deckedout2.rendering.components.RenderableComponent;
 import ca.cgutwin.deckedout2.rendering.components.TextureComponent;
+import ca.cgutwin.deckedout2.rendering.renderers.MapRenderer;
 import ca.cgutwin.deckedout2.rendering.renderers.TileEntityRenderer;
 import ca.cgutwin.deckedout2.util.DebugSystem;
+import ca.cgutwin.deckedout2.world.components.MapComponent;
 import ca.cgutwin.deckedout2.world.components.TileComponent;
 import com.badlogic.ashley.core.Engine;
 import com.badlogic.ashley.core.Entity;
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.maps.MapLayer;
 import com.badlogic.gdx.maps.MapProperties;
 import com.badlogic.gdx.maps.tiled.TiledMap;
@@ -17,27 +20,34 @@ public class MapLoader
 {
   private final TmxMapLoader mapLoader;
   private final Engine engine;
-  private TiledMap map;
+  private final Camera camera;
 
-  public MapLoader(Engine engine, String pathToMap) {
-    this(engine);
+  public MapLoader(Engine engine, Camera camera, String pathToMap) {
+    this(engine, camera);
     loadMap(pathToMap);
   }
 
-  public MapLoader(Engine engine) {
+  public MapLoader(Engine engine, Camera camera) {
     this.engine = engine;
+    this.camera = camera;
     mapLoader   = new TmxMapLoader();
   }
 
   public void loadMap(String pathToMap) {
     DebugSystem.getInstance().sout("loading map");
 
-    map = mapLoader.load(pathToMap);
+    Entity mapEntity = new Entity();
 
-    if (map != null) { DebugSystem.getInstance().sout("loaded " + map); }
+    MapComponent mapComponent = engine.createComponent(MapComponent.class);
+    mapComponent.map = mapLoader.load(pathToMap);
+    mapEntity.add(mapComponent);
+    RenderableComponent renderableComponent = new RenderableComponent(new MapRenderer());
+    renderableComponent.camera = camera;
+    mapEntity.add(renderableComponent);
 
-    assert map != null;
-    processMapLayers(map);
+    engine.addEntity(mapEntity);
+
+    processMapLayers(mapComponent.map);
   }
 
   private void processMapLayers(TiledMap map) {
@@ -78,9 +88,5 @@ public class MapLoader
 
     engine.addEntity(tileEntity);
     DebugSystem.getInstance().sout("added entity: " + tileEntity);
-  }
-
-  public TiledMap map() {
-    return map;
   }
 }

--- a/src/main/java/ca/cgutwin/deckedout2/world/MapLoader.java
+++ b/src/main/java/ca/cgutwin/deckedout2/world/MapLoader.java
@@ -16,40 +16,71 @@ import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
 
+/**
+ * The MapLoader class is responsible for loading and processing maps in the game world.
+ */
 public class MapLoader
 {
   private final TmxMapLoader mapLoader;
   private final Engine engine;
   private final Camera camera;
 
+  /**
+   * Constructs a MapLoader instance and immediately loads the specified map.
+   *
+   * @param engine    The Ashley engine for managing entities.
+   * @param camera    The camera for rendering the map.
+   * @param pathToMap The path to the Tiled map file to load.
+   */
   public MapLoader(Engine engine, Camera camera, String pathToMap) {
     this(engine, camera);
     loadMap(pathToMap);
   }
 
+  /**
+   * Constructs a MapLoader instance.
+   *
+   * @param engine The Ashley engine for managing entities.
+   * @param camera The camera for rendering the map.
+   */
   public MapLoader(Engine engine, Camera camera) {
     this.engine = engine;
     this.camera = camera;
     mapLoader   = new TmxMapLoader();
   }
 
+  /**
+   * Loads a Tiled map from the given path and adds it as an entity to the engine.
+   *
+   * @param pathToMap The path to the Tiled map file to load.
+   */
   public void loadMap(String pathToMap) {
     DebugSystem.getInstance().sout("loading map");
 
     Entity mapEntity = new Entity();
 
+    // Create a MapComponent and associate it with the loaded map
     MapComponent mapComponent = engine.createComponent(MapComponent.class);
     mapComponent.map = mapLoader.load(pathToMap);
     mapEntity.add(mapComponent);
+
+    // Create a RenderableComponent for rendering the map
     RenderableComponent renderableComponent = new RenderableComponent(new MapRenderer());
     renderableComponent.camera = camera;
     mapEntity.add(renderableComponent);
 
+    // Add the map entity to the engine
     engine.addEntity(mapEntity);
 
+    // Process map layers to create entities for tiles with "entity" property
     processMapLayers(mapComponent.map);
   }
 
+  /**
+   * Processes the layers of the Tiled map to create entities for tiles with the "entity" property.
+   *
+   * @param map The Tiled map to process.
+   */
   private void processMapLayers(TiledMap map) {
     for (MapLayer layer: map.getLayers()) {
       if (layer instanceof TiledMapTileLayer) {
@@ -58,6 +89,11 @@ public class MapLoader
     }
   }
 
+  /**
+   * Processes a specific tile layer to create entities for tiles with the "entity" property.
+   *
+   * @param tileLayer The Tiled map tile layer to process.
+   */
   private void processTileLayer(TiledMapTileLayer tileLayer) {
     for (int y = 0; y < tileLayer.getHeight(); y++) {
       for (int x = 0; x < tileLayer.getWidth(); x++) {
@@ -69,24 +105,40 @@ public class MapLoader
     }
   }
 
+  /**
+   * Checks if a tile cell should create an entity based on the "entity" property.
+   *
+   * @param cell The Tiled map tile cell to check.
+   * @return True if an entity should be created for the cell, false otherwise.
+   */
   private boolean shouldCreateEntityForCell(TiledMapTileLayer.Cell cell) {
     return cell.getTile().getProperties().containsKey("entity");
   }
 
+  /**
+   * Creates an entity for a specific tile cell.
+   *
+   * @param cell The Tiled map tile cell for which to create an entity.
+   * @param x    The x-coordinate of the cell.
+   * @param y    The y-coordinate of the cell.
+   */
   private void createEntityForCell(TiledMapTileLayer.Cell cell, int x, int y) {
     Entity tileEntity = new Entity();
 
+    // Get tile properties and type
     MapProperties properties = cell.getTile().getProperties();
     String tileType = properties.get("type", String.class);
 
+    // Create TileComponent and TextureComponent for the entity
     TileComponent tileComponent = new TileComponent(TileTypeEnum.valueOf(tileType), new Position(x, y));
     TextureComponent textureComponent = new TextureComponent(cell.getTile().getTextureRegion());
 
+    // Add components to the entity and add it to the engine
     tileEntity.add(new RenderableComponent(new TileEntityRenderer()));
     tileEntity.add(tileComponent);
     tileEntity.add(textureComponent);
-
     engine.addEntity(tileEntity);
+
     DebugSystem.getInstance().sout("added entity: " + tileEntity);
   }
 }

--- a/src/main/java/ca/cgutwin/deckedout2/world/components/MapComponent.java
+++ b/src/main/java/ca/cgutwin/deckedout2/world/components/MapComponent.java
@@ -3,7 +3,14 @@ package ca.cgutwin.deckedout2.world.components;
 import com.badlogic.ashley.core.Component;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 
+/**
+ * The MapComponent class represents a component that holds a reference to a TiledMap.
+ * It is used to associate a TiledMap with an entity in the Ashley framework.
+ */
 public class MapComponent implements Component
 {
+  /**
+   * The TiledMap associated with this component.
+   */
   public TiledMap map;
 }

--- a/src/main/java/ca/cgutwin/deckedout2/world/components/MapComponent.java
+++ b/src/main/java/ca/cgutwin/deckedout2/world/components/MapComponent.java
@@ -1,0 +1,9 @@
+package ca.cgutwin.deckedout2.world.components;
+
+import com.badlogic.ashley.core.Component;
+import com.badlogic.gdx.maps.tiled.TiledMap;
+
+public class MapComponent implements Component
+{
+  public TiledMap map;
+}


### PR DESCRIPTION
MapRenderer has been changd to now work as an entity in the RenderingSystem. The map is created and given a `RenderableComponent`, and a rendering strategy `MapRenderer`.